### PR TITLE
import Foundation and not Cocoa in HelperConstants.swift

### DIFF
--- a/SwiftPrivilegedHelperApplication/SwiftPrivilegedHelper/HelperConstants.swift
+++ b/SwiftPrivilegedHelperApplication/SwiftPrivilegedHelper/HelperConstants.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Erik Berglund. All rights reserved.
 //
 
-import Cocoa
+import Foundation
 
 let kAuthorizationRightKeyClass     = "class"
 let kAuthorizationRightKeyGroup     = "group"


### PR DESCRIPTION
Does not matter much since both libraries will be available on macos, but nothing from Cocoa is needed in this file, and this makes it explicit that the privileged helper does not have any UI